### PR TITLE
Provide cursory support for events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ function NDoc(files, options) {
       var ndocs = parser.parse(text);
       var id;
       // do pre-distribute early work
-      for (id in ndocs) {
+      for (id in ndocs) { 
         if (ndocs.hasOwnProperty(id)) {
           var d = ndocs[id];
           // assign hierarchy helpers
@@ -101,6 +101,7 @@ function NDoc(files, options) {
             // and will be resolved later, when we'll have full
             // element list
             list[(d.section || '') + '.' + d.id] = d;
+
             // bound methods produce two methods with the same description but different signatures
             // E.g. Element.foo(@element, a, b) becomes
             // Element.foo(element, a, b) and Element#foo(a, b)

--- a/lib/parser.y
+++ b/lib/parser.y
@@ -183,6 +183,7 @@ ndoc
   | namespace
   | class
   | mixin
+  | event_emitter
   | signatures
   | signatures argument_descriptions { $$.arguments = $2 }
   ;
@@ -295,7 +296,6 @@ namespace
   : name { $$ = {id: $1, type: 'namespace'}; }
   ;
 
-
 class
 
   /* vanilla */
@@ -366,6 +366,10 @@ method
   | name '(' '@' args ')' { $$ = {id: $1, type: 'method', args: $4, bound: true} }
   ;
 
+event_emitter
+
+  : name STRING ',' name '(' args ')' { $$ = {section: $1, id: $2, type: 'event_emitter', args: $6} }
+  ;
 
 returns
 
@@ -436,4 +440,6 @@ arg
 
   /* with ellipsis */
   | arg '...' { $$.ellipsis = true }
+
+  | NAME '(' ')' { $$ = {name: $1 + $2 + $3}; $$.callback = 'true' }
   ;


### PR DESCRIPTION
There's two things ndoc really needs in order to cover all Node.js use cases: events and callback documentation.

I'll readily admit that the code I'm requesting for a pull isn't 100% there. I just wrote up a quick example to illustrate what I'm talking about.

Certain classes can become event emitters; take HTTP.Server as an example. It's got events like 'request', 'connection', e.t.c., that can be added, removed, and whatever else.

I propose the following format to document events:

```
http.server "request", callback(request, response)
```

The first token helps the event find the right "class" it should be a part of; the second string indicates its name, and the third token indicates its callback function. The above code correlates to something like

```
http.server.on('request', function(request, response) { });
```

Very similarly, there needs to be some standard way to document callbacks in functions, too. I tried to extend parser.y for this but I'm extremely rusty with writing grammars. Ideally, you could document something like this:

```
dns.lookup(domain, family=null, callback(err, address, family))
```

In my head, it would just be a matter of extending `arg` to include a method, but I was getting some states with conflicts errors. I got around this by doing something lame, like adding a non-alphanumeric to the front

```
dns.lookup(domain, family=null, ~callback(err, address, family))
```

Can either of these be supported?
