### PR TITLE
Convert backslashes to slashes

### DIFF
--- a/bin/ndoc
+++ b/bin/ndoc
@@ -106,6 +106,9 @@ try {
 }());
 
 function interpolate(string, file, line) {
+  if (file) {
+    file = file.replace(/\\/g, '/');
+  }
   var r = string
     .replace(/\{url\}/g, opts.package.url || '')
     .replace(/\{file\}/g, file)


### PR DESCRIPTION
Fix for Windows path separator "\". When generating URLs to i.e. Github these backslashes must be converted to slashes.
